### PR TITLE
Apply user customizations

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,7 +9,7 @@ export default defineConfig({
     enabled: false
   },
   prefetch: true,
-  site: 'https://simoneballuer.netlify.app/',
+  site: 'https://jannisreinelt.netlify.app/',
   integrations: [sitemap()],
   experimental: {
     svg: true,

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -20,13 +20,19 @@ collections:
       - { label: Location, name: location, widget: string }
       - { label: Type (DE) z.B. "Bühnenbild", name: type, widget: string, required: false }
       - { label: Type (EN) z.B. "Stagedesign", name: type_en, widget: string, required: false }
+      - { label: Title, name: title, widget: string, required: false }
+      - { label: Content Type, name: content_type, widget: select, options: [text, image, video], default: image }
       - label: Images
         name: images
         widget: list
         fields:
           - { label: Image, name: src, widget: image }
           - { label: Alt Text, name: alt, widget: string }
+      - { label: Video URL, name: video, widget: string, required: false }
       - { label: Category, name: category, widget: select, options: [A,B,C], default: B }
       - { label: Orientation, name: orientation, widget: select, options: ['1:1.4','1.4:1'], default: '1:1.4' }
+      - { label: Order About, name: order_about, widget: number, required: false }
+      - { label: Order Projects, name: order_projects, widget: number, required: false }
+      - { label: Order Video, name: order_video, widget: number, required: false }
       - { label: Body (DE), name: body, widget: markdown, required: false  }
       - { label: Body (EN), name: body_en, widget: markdown, required: false }

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -10,7 +10,9 @@ const { project } = Astro.props;
 
 <div
   class="project"
-  style={`--image: url('${project.data.images[0].src}');`}
+  style={`--image: url('${project.data.images?.[0]?.src || ''}'); --aspect: ${
+    project.data.orientation === '1:1.4' ? '1 / 1.4' : '1.4 / 1'
+  };`}
   data-name={project.data.name}
   data-year={project.data.year}
   data-month={project.data.month}
@@ -18,7 +20,24 @@ const { project } = Astro.props;
   data-type={project.data.type}
   aria-label={project.data.name}
 >
-  {project.data.name}
+  {project.data.content_type === 'text' && (
+    <div class="rectangle-content">
+      {project.data.title && <h3>{project.data.title}</h3>}
+      <div set:html={project.body} />
+    </div>
+  )}
+  {project.data.content_type === 'video' && project.data.video && (
+    <video
+      class="hover-video"
+      src={project.data.video}
+      muted
+      loop
+      playsinline
+    ></video>
+  )}
+  {(!project.data.content_type || project.data.content_type === 'image') && (
+    <div class="image" />
+  )}
 </div>
 
 <style>
@@ -36,7 +55,7 @@ const { project } = Astro.props;
     background-image: var(--image);
     background-size: cover;
     background-position: center;
-    aspect-ratio: var(--aspect, 1.4 / 1);
+    aspect-ratio: var(--aspect, 1 / 1.4);
     border: 1px solid black;
     display: flex;
     align-items: center;

--- a/src/components/ProjectGrid.astro
+++ b/src/components/ProjectGrid.astro
@@ -4,17 +4,23 @@ import ProjectCard from "./ProjectCard.astro";
 
 type Props = {
   projects: CollectionEntry<"projects">[];
+  sortField?: string;
 };
 
-const { projects } = Astro.props;
+const { projects, sortField } = Astro.props;
 const grid = "projects";
 
-// Sort by year DESC, then month DESC
-const sortedProjects = [...projects].sort((a, b) => {
-  const yearDiff = (b.data.year ?? 0) - (a.data.year ?? 0);
-  if (yearDiff !== 0) return yearDiff;
-  return (b.data.month ?? 0) - (a.data.month ?? 0);
-});
+let sortedProjects = [...projects];
+if (sortField) {
+  sortedProjects.sort((a, b) => (a.data[sortField] ?? 0) - (b.data[sortField] ?? 0));
+} else {
+  // Sort by year DESC, then month DESC
+  sortedProjects.sort((a, b) => {
+    const yearDiff = (b.data.year ?? 0) - (a.data.year ?? 0);
+    if (yearDiff !== 0) return yearDiff;
+    return (b.data.month ?? 0) - (a.data.month ?? 0);
+  });
+}
 ---
 
 <section class="project-grid" id="grid" data-grid={grid}>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -10,14 +10,22 @@ const projects = defineCollection({
     location: z.string(),
     type: z.string(),
     type_en: z.string().optional(),
-    images: z.array(
-      z.object({
-        src: z.string(),
-        alt: z.string(),
-      })
-    ),
-    category: z.enum(['A','B','C']).default('B'),
-    orientation: z.enum(['1:1.4','1.4:1']).default('1:1.4'),
+    title: z.string().optional(),
+    images: z
+      .array(
+        z.object({
+          src: z.string(),
+          alt: z.string(),
+        })
+      )
+      .optional(),
+    video: z.string().optional(),
+    content_type: z.enum(['text', 'image', 'video']).default('image'),
+    category: z.enum(['A', 'B', 'C']).default('B'),
+    orientation: z.enum(['1:1.4', '1.4:1']).default('1:1.4'),
+    order_about: z.number().optional(),
+    order_projects: z.number().optional(),
+    order_video: z.number().optional(),
     body_en: z.string().optional(),
   }),
 });

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -35,7 +35,7 @@ const currentPage =
         basic: {
           title: title,
           type: "image/jpeg",
-          image: "/simoneballuer-og.jpg",
+          image: "/jannisreinelt-og.jpg",
         },
       }}
     
@@ -71,7 +71,7 @@ const currentPage =
         ],
         // extending the default meta tags
         meta: [
-          { name: "twitter:image", content: "/simoneballuer-og.jpg" },
+          { name: "twitter:image", content: "/jannisreinelt-og.jpg" },
           { name: "twitter:title", content: title },
           { name: "twitter:description", content: description },
           { name: "viewport", content: "width=device-width" },
@@ -91,6 +91,7 @@ const currentPage =
     <script src="../scripts/gallery.js"></script>
     <script src="../scripts/themeToggle.js"></script>
     <script src="../scripts/langToggle.js"></script>
+    <script src="../scripts/videoHover.js"></script>
   </body>
   <Footer/>
 </html>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,12 +1,15 @@
 ---
+import { getCollection } from "astro:content";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import ProjectGrid from "../components/ProjectGrid.astro";
+import Preloader from "../components/Preloader.astro";
 
 const title = "Jannis Reinelt - About";
+const allProjects = await getCollection("projects");
+const projects = allProjects.filter((p) => p.data.category === 'A');
 ---
 
 <BaseLayout title={title}>
-  <div class="content content--page">
-    <p>simone.ballueer@posteo.de</p>
-    <p></p>
-  </div>
+  <Preloader />
+  <ProjectGrid projects={projects} sortField="order_about" />
 </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,7 +6,8 @@ import ProjectGridHeader from "../components/ProjectGridHeader.astro";
 import Preloader from "../components/Preloader.astro";
 
 const allProjects = await getCollection("projects");
-const projectsTotal = allProjects.length;
+const projects = allProjects.filter((p) => p.data.category === 'B');
+const projectsTotal = projects.length;
 const title = "Jannis Reinelt";
 ---
 
@@ -17,6 +18,6 @@ const title = "Jannis Reinelt";
   --->
   <Preloader />
  <!--  <ProjectGridHeader projectsTotal={projectsTotal} />   --->
-  <ProjectGrid projects={allProjects} />
+  <ProjectGrid projects={projects} sortField="order_projects" />
 </BaseLayout>
 <script src="../scripts/index.js"></script>

--- a/src/pages/video-light-camera.astro
+++ b/src/pages/video-light-camera.astro
@@ -1,11 +1,15 @@
 ---
+import { getCollection } from "astro:content";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import ProjectGrid from "../components/ProjectGrid.astro";
+import Preloader from "../components/Preloader.astro";
 
 const title = "Jannis Reinelt - Video/Light/Camera";
+const allProjects = await getCollection("projects");
+const projects = allProjects.filter((p) => p.data.category === 'C');
 ---
 
 <BaseLayout title={title}>
-  <div class="content content--page">
-    <p>Coming soon...</p>
-  </div>
+  <Preloader />
+  <ProjectGrid projects={projects} sortField="order_video" />
 </BaseLayout>

--- a/src/scripts/videoHover.js
+++ b/src/scripts/videoHover.js
@@ -1,0 +1,13 @@
+const init = () => {
+  const videos = document.querySelectorAll('.hover-video');
+  videos.forEach((vid) => {
+    vid.addEventListener('mouseenter', () => {
+      vid.play();
+    });
+    vid.addEventListener('mouseleave', () => {
+      vid.pause();
+    });
+  });
+};
+
+document.addEventListener('astro:page-load', init);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -303,7 +303,7 @@ dd {
 
 .content-rectangle {
   background-color: var(--content-bg-color, #fff);
-  aspect-ratio: var(--aspect, 1.4 / 1);
+  aspect-ratio: var(--aspect, 1 / 1.4);
   overflow-y: hidden;
   padding: 1.5rem 3rem;
   display: flex;


### PR DESCRIPTION
## Summary
- update site config to Jannis Reinelt
- add CMS fields for content type and ordering
- support project filtering and orientation
- show project grids on all pages by category
- add hover video support

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688ab65de65c83279d26ba22e29b0227