### PR TITLE
Implement consistent responsive project cards

### DIFF
--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -10,7 +10,7 @@ const { project } = Astro.props;
 
 <div
   class="project"
-  style={`--image: url('${project.data.images?.[0]?.src ?? ''}'); --aspect: ${project.data.orientation === '1.4:1' ? '1.4/1' : '1/1.4'}`}
+  style={`--image: url('${project.data.images?.[0]?.src ?? ''}');`}
   data-name={project.data.name}
   data-year={project.data.year}
   data-month={project.data.month}
@@ -20,7 +20,7 @@ const { project } = Astro.props;
 >
   {project.data.kind === 'text' && (
     <div class="rectangle-content">
-      <h3>{project.data.name}</h3>
+      <div class="titlebox"><h3>{project.data.name}</h3></div>
       <p>{project.body}</p>
     </div>
   )}
@@ -50,12 +50,13 @@ const { project } = Astro.props;
     background-image: var(--image);
     background-size: cover;
     background-position: center;
-    aspect-ratio: var(--aspect, 1 / 1.4);
+    aspect-ratio: 1 / 1.4;
     border: 1px solid black;
     display: flex;
     align-items: center;
     justify-content: center;
     width: 100%;
+    max-width: 26.1rem;
     box-shadow: 0 4px 16px rgba(61, 61, 61, 0.2);
     overflow: hidden;
   }

--- a/src/components/ProjectGrid.astro
+++ b/src/components/ProjectGrid.astro
@@ -18,26 +18,16 @@ const sortedProjects = projects;
 
 
 <style>
-section {
+  section {
     position: relative;
     overflow: visible;
     display: grid;
     width: 100%;
     max-width: 100vw; /* Prevents overflow */
     box-sizing: border-box;
-    grid-template-columns: repeat(1, 1fr);
-    gap: 2rem; /* Smaller gap for mobile */
+    grid-template-columns: repeat(auto-fit, minmax(26.1rem, 1fr));
+    gap: 1rem;
     margin: 1rem 0 10rem;
     min-height: 400px;
-  }
- 
-  
-  @media screen and (min-width: 50em) {
-    section {
-      grid-template-columns: repeat(2, 1fr);
-      gap: 5rem; /* Reduce gap for large screens */
-      margin: 2rem 0 10rem;
-    
-    }
   }
 </style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -314,11 +314,22 @@ dd {
 .rectangle-content {
   flex: 1;
   display: flex;
-  justify-content: center;
-  align-items: center;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: flex-start;
   text-align: justify;
   word-break: normal;
-  flex-direction: column;
+}
+
+.titlebox {
+  height: 2rem;
+  min-height: 4rem;
+  max-height: 3rem;
+  padding: 0;
+  overflow-y: hidden;
+  text-align: left;
+  font-weight: bold;
+  width: 100%;
 }
 
 .rectangle-content p { margin: 0; }


### PR DESCRIPTION
## Summary
- adjust `.rectangle-content` layout and add `.titlebox`
- make text card title a dedicated element at top
- set fixed aspect ratio for project cards
- allow project grid to auto-fit cards responsively

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688b5bf37f708327ab0bc0d04d2d48b2