### PR TITLE
Make project card rectangle uniform

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -28,7 +28,6 @@ collections:
           - { label: Image, name: src, widget: image }
           - { label: Alt Text, name: alt, widget: string }
       - { label: Category, name: category, widget: select, options: [A,B,C], default: B }
-      - { label: Orientation, name: orientation, widget: select, options: ['1:1.4','1.4:1'], default: '1:1.4' }
       - { label: Kind, name: kind, widget: select, options: [image,text,video], default: image }
       - { label: Video URL, name: video, widget: string, required: false }
       - { label: Order About, name: order_about, widget: number, required: false }

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -10,7 +10,7 @@ const { project } = Astro.props;
 
 <div
   class="project"
-  style={`--image: url('${project.data.images?.[0]?.src ?? ''}'); --aspect: ${project.data.orientation === '1.4:1' ? '1.4/1' : '1/1.4'}`}
+  style={`--image: url('${project.data.images?.[0]?.src ?? ''}'); --rect-aspect: 1/1.417`}
   data-name={project.data.name}
   data-year={project.data.year}
   data-month={project.data.month}
@@ -20,7 +20,7 @@ const { project } = Astro.props;
 >
   {project.data.kind === 'text' && (
     <div class="rectangle-content">
-      <h3>{project.data.name}</h3>
+      <div class="titlebox"><h3>{project.data.name}</h3></div>
       <p>{project.body}</p>
     </div>
   )}
@@ -50,14 +50,27 @@ const { project } = Astro.props;
     background-image: var(--image);
     background-size: cover;
     background-position: center;
-    aspect-ratio: var(--aspect, 1 / 1.4);
+    width: var(--rect-width, 26.1rem);
+    aspect-ratio: var(--rect-aspect, 1 / 1.417);
+    height: auto;
     border: 1px solid black;
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 100%;
     box-shadow: 0 4px 16px rgba(61, 61, 61, 0.2);
     overflow: hidden;
+  }
+
+  .titlebox {
+    height: 2rem;
+    overflow-y: hidden;
+    text-align: left;
+    font-weight: bold;
+  }
+
+  .rectangle-content {
+    align-items: flex-start;
+    flex-direction: column;
   }
   .images img,
   video {

--- a/src/components/ProjectGrid.astro
+++ b/src/components/ProjectGrid.astro
@@ -25,19 +25,10 @@ section {
     width: 100%;
     max-width: 100vw; /* Prevents overflow */
     box-sizing: border-box;
-    grid-template-columns: repeat(1, 1fr);
-    gap: 2rem; /* Smaller gap for mobile */
+    grid-template-columns: repeat(auto-fit, minmax(var(--rect-width, 26.1rem), 1fr));
+    gap: 2rem;
+    justify-content: center;
     margin: 1rem 0 10rem;
     min-height: 400px;
-  }
- 
-  
-  @media screen and (min-width: 50em) {
-    section {
-      grid-template-columns: repeat(2, 1fr);
-      gap: 5rem; /* Reduce gap for large screens */
-      margin: 2rem 0 10rem;
-    
-    }
   }
 </style>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -24,7 +24,6 @@ const projects = defineCollection({
     order_projects: z.number().optional(),
     order_video: z.number().optional(),
     category: z.enum(['A', 'B', 'C']).default('B'),
-    orientation: z.enum(['1:1.4', '1.4:1']).default('1:1.4'),
     body_en: z.string().optional(),
   }),
 });

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -303,7 +303,8 @@ dd {
 
 .content-rectangle {
   background-color: var(--content-bg-color, #fff);
-  aspect-ratio: var(--aspect, 1 / 1.4);
+  width: var(--rect-width, 26.1rem);
+  aspect-ratio: var(--rect-aspect, 1 / 1.417);
   overflow-y: hidden;
   padding: 1.5rem 3rem;
   display: flex;
@@ -315,10 +316,16 @@ dd {
   flex: 1;
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: flex-start;
   text-align: justify;
   word-break: normal;
   flex-direction: column;
+}
+.titlebox {
+  height: 2rem;
+  overflow-y: hidden;
+  text-align: left;
+  font-weight: bold;
 }
 
 .rectangle-content p { margin: 0; }


### PR DESCRIPTION
## Summary
- make the project grid responsive with `auto-fit`
- make cards use a constant rectangle aspect ratio
- adjust card markup for a title wrapper
- add global styles for `.titlebox` and update rectangle CSS
- drop unused `orientation` field

## Testing
- `npm run build` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b6a634cac832796a70dbbb4ce4bc6