### PR TITLE
Implement video hover play and CMS updates

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -15,12 +15,7 @@ collections:
     slug: "{{name}}"
     sortable_fields: [commit_date, year]
     fields:
-      - { label: Name, name: name, widget: string }
-      - { label: Year, name: year, widget: number }
-      - { label: Month in numbers from "1" to "12", name: month, widget: number, min: 1, max: 12 }
-      - { label: Location, name: location, widget: string }
-      - { label: Type (DE) z.B. "Bühnenbild", name: type, widget: string, required: false }
-      - { label: Type (EN) z.B. "Stagedesign", name: type_en, widget: string, required: false }
+      - { label: Title, name: title, widget: string, required: false }
       - label: Images
         name: images
         widget: list

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -20,7 +20,7 @@ const { project } = Astro.props;
 >
   {project.data.kind === 'text' && (
     <div class="rectangle-content">
-      <div class="titlebox"><h3>{project.data.name}</h3></div>
+      <div class="titlebox"><h3>{project.data.title ?? project.data.name}</h3></div>
       <p>{project.body}</p>
     </div>
   )}
@@ -30,7 +30,10 @@ const { project } = Astro.props;
     </div>
   )}
   {project.data.kind === 'video' && project.data.video && (
-    <video src={project.data.video} muted loop playsinline></video>
+    <div class="video-wrapper">
+      <video src={project.data.video} muted loop playsinline></video>
+      <button class="mute-toggle" aria-label="Toggle sound">Mute</button>
+    </div>
   )}
 </div>
 
@@ -71,6 +74,25 @@ const { project } = Astro.props;
   .rectangle-content {
     align-items: flex-start;
     flex-direction: column;
+    padding: 2rem;
+    padding-top: calc(2rem + 10%);
+    box-sizing: border-box;
+  }
+  .video-wrapper {
+    position: relative;
+    width: 100%;
+    height: 100%;
+  }
+  .mute-toggle {
+    position: absolute;
+    left: 0.5rem;
+    bottom: 0.5rem;
+    z-index: 1;
+    background: rgba(0,0,0,0.5);
+    color: white;
+    border: none;
+    padding: 0.25rem 0.5rem;
+    cursor: pointer;
   }
   .images img,
   video {

--- a/src/components/ProjectGrid.astro
+++ b/src/components/ProjectGrid.astro
@@ -25,7 +25,7 @@ section {
     width: 100%;
     max-width: 100vw; /* Prevents overflow */
     box-sizing: border-box;
-    grid-template-columns: repeat(auto-fit, minmax(var(--rect-width, 26.1rem), 1fr));
+    grid-template-columns: repeat(auto-fill, var(--rect-width, 26.1rem));
     gap: 2rem;
     justify-content: center;
     margin: 1rem 0 10rem;

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -10,6 +10,7 @@ const projects = defineCollection({
     location: z.string(),
     type: z.string(),
     type_en: z.string().optional(),
+    title: z.string().optional(),
     images: z
       .array(
         z.object({

--- a/src/scripts/videoHover.js
+++ b/src/scripts/videoHover.js
@@ -1,21 +1,20 @@
 const init = () => {
-  const videos = document.querySelectorAll('.project video');
-  videos.forEach((video) => {
-    video.addEventListener('mouseenter', () => video.play());
-    video.addEventListener('mouseleave', () => video.pause());
+  const wrappers = document.querySelectorAll('.video-wrapper');
+  wrappers.forEach((wrapper) => {
+    const video = wrapper.querySelector('video');
+    const button = wrapper.querySelector('.mute-toggle');
+    if (!video || !button) return;
 
-    if ('IntersectionObserver' in window) {
-      const observer = new IntersectionObserver((entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            video.play();
-          } else {
-            video.pause();
-          }
-        });
-      }, { threshold: 1.0 });
-      observer.observe(video);
-    }
+    wrapper.addEventListener('mouseenter', () => video.play());
+    wrapper.addEventListener('mouseleave', () => {
+      video.pause();
+      video.currentTime = 0;
+    });
+
+    button.addEventListener('click', () => {
+      video.muted = !video.muted;
+      button.textContent = video.muted ? 'Mute' : 'Unmute';
+    });
   });
 };
 


### PR DESCRIPTION
## Summary
- add mute/unmute toggle on videos and play only on hover
- center project grid with constant gap
- support optional project title and style text rectangles
- remove some fields from Decap CMS config

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688b72ddb4c88327903684dfb7f5900e