### PR TITLE
Implement video hover playback and update CMS

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -12,15 +12,10 @@ collections:
     folder: "src/data/projects"
     create: true
     extension: md
-    slug: "{{name}}"
-    sortable_fields: [commit_date, year]
+    slug: "{{slug}}"
+    sortable_fields: [commit_date]
     fields:
-      - { label: Name, name: name, widget: string }
-      - { label: Year, name: year, widget: number }
-      - { label: Month in numbers from "1" to "12", name: month, widget: number, min: 1, max: 12 }
-      - { label: Location, name: location, widget: string }
-      - { label: Type (DE) z.B. "Bühnenbild", name: type, widget: string, required: false }
-      - { label: Type (EN) z.B. "Stagedesign", name: type_en, widget: string, required: false }
+      - { label: Title, name: title, widget: string, required: false }
       - label: Images
         name: images
         widget: list

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -6,21 +6,22 @@ type Props = {
 };
 
 const { project } = Astro.props;
+const title = project.data.title ?? project.data.name;
 ---
 
 <div
-  class="project"
+  class={`project ${project.data.kind}`}
   style={`--image: url('${project.data.images?.[0]?.src ?? ''}'); --rect-aspect: 1/1.417`}
-  data-name={project.data.name}
+  data-name={title}
   data-year={project.data.year}
   data-month={project.data.month}
   data-location={project.data.location}
   data-type={project.data.type}
-  aria-label={project.data.name}
+  aria-label={title}
 >
   {project.data.kind === 'text' && (
     <div class="rectangle-content">
-      <div class="titlebox"><h3>{project.data.name}</h3></div>
+      <div class="titlebox"><h3>{title}</h3></div>
       <p>{project.body}</p>
     </div>
   )}
@@ -30,7 +31,10 @@ const { project } = Astro.props;
     </div>
   )}
   {project.data.kind === 'video' && project.data.video && (
-    <video src={project.data.video} muted loop playsinline></video>
+    <div class="video-container">
+      <video src={project.data.video} muted loop playsinline></video>
+      <button class="mute-toggle">Unmute</button>
+    </div>
   )}
 </div>
 
@@ -60,6 +64,9 @@ const { project } = Astro.props;
     box-shadow: 0 4px 16px rgba(61, 61, 61, 0.2);
     overflow: hidden;
   }
+  .project.text {
+    align-items: flex-start;
+  }
 
   .titlebox {
     height: 2rem;
@@ -71,6 +78,8 @@ const { project } = Astro.props;
   .rectangle-content {
     align-items: flex-start;
     flex-direction: column;
+    padding: 2rem;
+    padding-top: 10%;
   }
   .images img,
   video {
@@ -80,5 +89,21 @@ const { project } = Astro.props;
   }
   video {
     display: block;
+  }
+  .video-container {
+    position: relative;
+    width: 100%;
+    height: 100%;
+  }
+  .mute-toggle {
+    position: absolute;
+    bottom: 0.5rem;
+    left: 0.5rem;
+    padding: 0.25rem 0.5rem;
+    font-size: 0.75rem;
+    background: rgba(0, 0, 0, 0.5);
+    color: #fff;
+    border: none;
+    cursor: pointer;
   }
 </style>

--- a/src/components/ProjectGrid.astro
+++ b/src/components/ProjectGrid.astro
@@ -25,7 +25,7 @@ section {
     width: 100%;
     max-width: 100vw; /* Prevents overflow */
     box-sizing: border-box;
-    grid-template-columns: repeat(auto-fit, minmax(var(--rect-width, 26.1rem), 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(var(--rect-width, 26.1rem), var(--rect-width, 26.1rem)));
     gap: 2rem;
     justify-content: center;
     margin: 1rem 0 10rem;

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -4,11 +4,12 @@ import { glob } from 'astro/loaders';
 const projects = defineCollection({
   loader: glob({ pattern: '**/*.md', base: './src/data/projects' }),
   schema: z.object({
-    name: z.string(),
-    year: z.number(),
-    month: z.number(),
-    location: z.string(),
-    type: z.string(),
+    name: z.string().optional(),
+    title: z.string().optional(),
+    year: z.number().optional(),
+    month: z.number().optional(),
+    location: z.string().optional(),
+    type: z.string().optional(),
     type_en: z.string().optional(),
     images: z
       .array(

--- a/src/scripts/videoHover.js
+++ b/src/scripts/videoHover.js
@@ -1,21 +1,19 @@
 const init = () => {
   const videos = document.querySelectorAll('.project video');
   videos.forEach((video) => {
+    const container = video.closest('.project');
+    const toggle = container?.querySelector('.mute-toggle');
+
+    if (toggle) {
+      toggle.addEventListener('click', (e) => {
+        e.stopPropagation();
+        video.muted = !video.muted;
+        toggle.textContent = video.muted ? 'Unmute' : 'Mute';
+      });
+    }
+
     video.addEventListener('mouseenter', () => video.play());
     video.addEventListener('mouseleave', () => video.pause());
-
-    if ('IntersectionObserver' in window) {
-      const observer = new IntersectionObserver((entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            video.play();
-          } else {
-            video.pause();
-          }
-        });
-      }, { threshold: 1.0 });
-      observer.observe(video);
-    }
   });
 };
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -306,7 +306,7 @@ dd {
   width: var(--rect-width, 26.1rem);
   aspect-ratio: var(--rect-aspect, 1 / 1.417);
   overflow-y: hidden;
-  padding: 1.5rem 3rem;
+  padding: 2rem;
   display: flex;
   flex-direction: column;
   border: 0 solid black;
@@ -315,11 +315,13 @@ dd {
 .rectangle-content {
   flex: 1;
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: flex-start;
   text-align: justify;
   word-break: normal;
   flex-direction: column;
+  padding: 2rem;
+  padding-top: 10%;
 }
 .titlebox {
   height: 2rem;


### PR DESCRIPTION
## Summary
- add mute toggles and hover-only playback for videos
- center grid with fixed spacing
- style text rectangles with padding and top offset
- simplify CMS fields and allow optional title
- update content schema accordingly

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688b72ddb4c88327903684dfb7f5900e