### PR TITLE
Enable mobile video autoplay on scroll

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -92,6 +92,7 @@ const currentPage =
     <script src="../scripts/themeToggle.js"></script>
     <script src="../scripts/langToggle.js"></script>
     <script src="../scripts/videoHover.js"></script>
+    <script src="../scripts/videoAutoPlay.js"></script>
   </body>
   <Footer/>
 </html>

--- a/src/scripts/videoAutoPlay.js
+++ b/src/scripts/videoAutoPlay.js
@@ -1,0 +1,24 @@
+const init = () => {
+  if (!window.matchMedia('(max-width: 50em)').matches) return;
+
+  const wrappers = document.querySelectorAll('.video-wrapper');
+  if (!wrappers.length) return;
+
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach((entry) => {
+      const video = entry.target.querySelector('video');
+      if (!video) return;
+
+      if (entry.isIntersecting) {
+        video.play();
+      } else {
+        video.pause();
+        video.currentTime = 0;
+      }
+    });
+  }, { threshold: 0.5 });
+
+  wrappers.forEach((wrapper) => observer.observe(wrapper));
+};
+
+document.addEventListener('astro:page-load', init);


### PR DESCRIPTION
## Summary
- automatically play video cards on mobile once in viewport
- load autoplay script in base layout

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688b857f49fc8327bd1f4472aa7d6dce