### PR TITLE
Implement language toggle and contact page

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -14,9 +14,30 @@ import Separator from "./Separator.astro";
   <Separator />
   <nav>
     <ul>
-      <li><a href="/about/"><TextSlider content="about" /></a></li>
-      <li><a href="/"><TextSlider content="art/projects" /></a></li>
-      <li><a href="/video-light-camera/"><TextSlider content="video/light/camera" /></a></li>
+      <li>
+        <a href="/about/">
+          <span class="lang-de"><TextSlider content="über" /></span>
+          <span class="lang-en"><TextSlider content="about" /></span>
+        </a>
+      </li>
+      <li>
+        <a href="/">
+          <span class="lang-de"><TextSlider content="kunst/projekte" /></span>
+          <span class="lang-en"><TextSlider content="art/projects" /></span>
+        </a>
+      </li>
+      <li>
+        <a href="/video-light-camera/">
+          <span class="lang-de"><TextSlider content="video/licht/kamera" /></span>
+          <span class="lang-en"><TextSlider content="video/light/camera" /></span>
+        </a>
+      </li>
+      <li>
+        <a href="/contact/">
+          <span class="lang-de"><TextSlider content="kontakt" /></span>
+          <span class="lang-en"><TextSlider content="contact" /></span>
+        </a>
+      </li>
     </ul>
   </nav>
 </header>

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -20,8 +20,13 @@ const { project } = Astro.props;
 >
   {project.data.kind === 'text' && (
     <div class="rectangle-content">
-      <div class="titlebox"><h3>{project.data.title ?? project.data.name}</h3></div>
-      <p>{project.body}</p>
+      <div class="titlebox">
+        <h3>{project.data.title ?? project.data.name}</h3>
+      </div>
+      <p>
+        <span class="lang-de">{project.body}</span>
+        <span class="lang-en">{project.data.body_en ?? project.body}</span>
+      </p>
     </div>
   )}
   {project.data.kind === 'image' && project.data.images && (

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,0 +1,19 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+const title = "Jannis Reinelt - Contact";
+---
+<BaseLayout title={title}>
+  <main class="contact-page">
+    <p>jannis.reinelt@posteo.de</p>
+  </main>
+</BaseLayout>
+
+<style>
+  .contact-page {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 60vh;
+    font-size: var(--font-size-xl);
+  }
+</style>

--- a/src/scripts/langToggle.js
+++ b/src/scripts/langToggle.js
@@ -15,3 +15,4 @@ const init = () => {
 };
 
 document.addEventListener('astro:page-load', init);
+document.addEventListener('astro:after-swap', init);

--- a/src/scripts/videoAutoPlay.js
+++ b/src/scripts/videoAutoPlay.js
@@ -16,7 +16,7 @@ const init = () => {
         video.currentTime = 0;
       }
     });
-  }, { threshold: 0.5 });
+  }, { threshold: 1 });
 
   wrappers.forEach((wrapper) => observer.observe(wrapper));
 };


### PR DESCRIPTION
## Summary
- enable nav translation and new Contact link
- localize project card text using `body_en` content
- adjust language toggle script
- update mobile video autoplay threshold
- add Contact page with email in center

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688b9a270edc83279464d0f35435f41a