### PR TITLE
Fix Decap CMS GitHub login path

### DIFF
--- a/netlify/functions/github-oauth.js
+++ b/netlify/functions/github-oauth.js
@@ -7,10 +7,13 @@ export async function handler(event) {
   const code = event.queryStringParameters.code;
 
   if (!code) {
+    const redirectUri = `${event.headers["x-forwarded-proto"] || "https"}://${event.headers.host}/.netlify/functions/github-oauth`;
     return {
       statusCode: 302,
       headers: {
-        Location: `https://github.com/login/oauth/authorize?client_id=${CLIENT_ID}&scope=repo`,
+        Location: `https://github.com/login/oauth/authorize?client_id=${CLIENT_ID}&scope=repo&redirect_uri=${encodeURIComponent(
+          redirectUri,
+        )}`,
       },
     };
   }
@@ -36,11 +39,13 @@ export async function handler(event) {
     return { statusCode: 500, body: JSON.stringify(tokenData) };
   }
 
+  const host = `${event.headers["x-forwarded-proto"] || "https"}://${event.headers.host}`;
+
   // Redirect back to CMS with token
   return {
     statusCode: 302,
     headers: {
-      Location: `/admin/?t=${accessToken}`,
+      Location: `${host}/admin/?t=${accessToken}`,
     },
   };
 }

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -3,7 +3,8 @@ backend:
   repo: meinrehlein/jrweb
   branch: main
   auth_type: implicit
-  base_url: https://meinrehlein.netlify.app/netlify/functions/github-oauth
+  base_url: https://meinrehlein.netlify.app/.netlify/functions
+  auth_endpoint: github-oauth
   site_domain: https://meinrehlein.netlify.app
 
 


### PR DESCRIPTION
## Summary
- fix GitHub OAuth base URL and auth endpoint in Decap CMS config

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0dbacaff8832793cbc7ef16ae7ad1