### PR TITLE
Fix Decap CMS GitHub login path

### DIFF
--- a/netlify/functions/github-oauth.js
+++ b/netlify/functions/github-oauth.js
@@ -5,12 +5,17 @@ const CLIENT_SECRET = process.env.GITHUB_CLIENT_SECRET;
 
 export async function handler(event) {
   const code = event.queryStringParameters.code;
+  const protocol = event.headers["x-forwarded-proto"] || "https";
+  const siteUrl = process.env.URL || `${protocol}://${event.headers.host}`;
+  const redirectUri = `${siteUrl}/.netlify/functions/github-oauth`;
 
   if (!code) {
     return {
       statusCode: 302,
       headers: {
-        Location: `https://github.com/login/oauth/authorize?client_id=${CLIENT_ID}&scope=repo`,
+        Location: `https://github.com/login/oauth/authorize?client_id=${CLIENT_ID}&scope=repo&redirect_uri=${encodeURIComponent(
+          redirectUri,
+        )}`,
       },
     };
   }
@@ -40,7 +45,7 @@ export async function handler(event) {
   return {
     statusCode: 302,
     headers: {
-      Location: `/admin/?t=${accessToken}`,
+      Location: `${siteUrl}/admin/?t=${accessToken}`,
     },
   };
 }

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -2,11 +2,9 @@ backend:
   name: github
   repo: meinrehlein/jrweb
   branch: main
-  auth_type: implicit
-  base_url: https://meinrehlein.netlify.app/netlify/functions/github-oauth
+  base_url: https://meinrehlein.netlify.app/.netlify/functions
+  auth_endpoint: github-oauth
   site_domain: https://meinrehlein.netlify.app
-
-
 
 media_folder: "public/images/uploads"
 public_folder: "/images/uploads"


### PR DESCRIPTION
## Summary
- ensure GitHub OAuth uses canonical site URL to avoid redirect URI errors
- streamline Decap CMS config for GitHub backend

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0dbacaff8832793cbc7ef16ae7ad1