### PR TITLE
Add online visibility flag for markdown projects

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -62,6 +62,12 @@ content:
           values: [image, text, video]
         default: image
 
+      - name: online
+        label: Online
+        type: boolean
+        required: false
+        default: true
+
       - name: video
         label: Video URL
         type: string

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -29,6 +29,7 @@ collections:
           - { label: Alt Text, name: alt, widget: string }
       - { label: Category, name: category, widget: select, options: [A,B,C], default: B }
       - { label: Kind, name: kind, widget: select, options: [image,text,video], default: image }
+      - { label: Online, name: online, widget: boolean, default: true }
       - { label: Video URL, name: video, widget: string, required: false }
       - { label: Video Starttime, name: startTime, widget: number, required: false }
       - { label: Order About, name: order_about, widget: number, required: false }

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -5,6 +5,7 @@ const projects = defineCollection({
   loader: glob({ pattern: '**/*.md', base: './src/data/projects' }),
   schema: z.object({
     name: z.string(),
+    online: z.boolean().default(true),
     title: z.string().optional(),
     images: z
       .array(

--- a/src/data/projects/2025-08-17-sososop.md
+++ b/src/data/projects/2025-08-17-sososop.md
@@ -1,5 +1,6 @@
 ---
 name: sososop
+online: true
 category: B
 kind: image
 startTime: 0

--- a/src/data/projects/2025-08-17-test.md
+++ b/src/data/projects/2025-08-17-test.md
@@ -1,5 +1,6 @@
 ---
 name: test
+online: true
 filename: tesggg
 title: hhh
 category: B

--- a/src/data/projects/404NotFound_video_videodokumentationausschnitt.md
+++ b/src/data/projects/404NotFound_video_videodokumentationausschnitt.md
@@ -1,5 +1,6 @@
 ---
 name: 404NotFound_video_videodokumentationausschnitt
+online: true
 title: 404NotFound_video_videodokumentationausschnitt
 category: B
 kind: video

--- a/src/data/projects/AllesSuper_video_mercedesboysquerformat.md
+++ b/src/data/projects/AllesSuper_video_mercedesboysquerformat.md
@@ -1,5 +1,6 @@
 ---
 name: AllesSuper_video_mercedesboysquerformat
+online: true
 title: AllesSuper_video_mercedesboysquerformat
 category: B
 kind: video

--- a/src/data/projects/AllesSuper_video_waschanlagecloseup.md
+++ b/src/data/projects/AllesSuper_video_waschanlagecloseup.md
@@ -1,5 +1,6 @@
 ---
 name: AllesSuper_video_waschanlagecloseup
+online: true
 title: AllesSuper_video_waschanlagecloseup
 category: B
 kind: video

--- a/src/data/projects/MeinJahrDerRuheUndEntspannung_video.md
+++ b/src/data/projects/MeinJahrDerRuheUndEntspannung_video.md
@@ -1,5 +1,6 @@
 ---
 name: MeinJahrDerRuheUndEntspannung_video
+online: true
 title: MeinJahrDerRuheUndEntspannung_video
 category: B
 kind: video

--- a/src/data/projects/Momentum_video_keyboard.md
+++ b/src/data/projects/Momentum_video_keyboard.md
@@ -1,5 +1,6 @@
 ---
 name: Momentum_video_keyboard
+online: true
 title: Momentum_video_keyboard
 category: B
 kind: video

--- a/src/data/projects/Momentum_video_keyboard2.md
+++ b/src/data/projects/Momentum_video_keyboard2.md
@@ -1,5 +1,6 @@
 ---
 name: Momentum_video_keyboard2
+online: true
 title: Momentum_video_keyboard2
 category: B
 kind: video

--- a/src/data/projects/Spiegelung_video.md
+++ b/src/data/projects/Spiegelung_video.md
@@ -1,5 +1,6 @@
 ---
 name: Spiegelung_video
+online: true
 title: Spiegelung_video
 category: B
 kind: video

--- a/src/data/projects/UTB_video_ofen3danimation.md
+++ b/src/data/projects/UTB_video_ofen3danimation.md
@@ -1,5 +1,6 @@
 ---
 name: UTB_video_ofen3danimation
+online: true
 title: UTB_video_ofen3danimation
 category: B
 kind: video

--- a/src/data/projects/UTB_video_videodokumentation_ausschnitt.md
+++ b/src/data/projects/UTB_video_videodokumentation_ausschnitt.md
@@ -1,5 +1,6 @@
 ---
 name: UTB_video_videodokumentation_ausschnitt
+online: true
 title: UTB_video_videodokumentation_ausschnitt
 category: B
 kind: video

--- a/src/data/projects/alles_super_close_video.md
+++ b/src/data/projects/alles_super_close_video.md
@@ -1,5 +1,6 @@
 ---
 name: alles_super_close_video
+online: true
 category: B
 kind: video
 video: https://stream.mux.com/wQHVVM9UxwWzl2obo02GQlLvRoEXdUktmgDjDh02i1r7c.m3u8

--- a/src/data/projects/jr-01.md
+++ b/src/data/projects/jr-01.md
@@ -1,5 +1,6 @@
 ---
 name: jr-01
+online: true
 title: jr-01
 images:
   - src: /images/uploads/jr-01.jpg

--- a/src/data/projects/jr-02.md
+++ b/src/data/projects/jr-02.md
@@ -1,5 +1,6 @@
 ---
 name: jr-02
+online: true
 title: jr-02
 images:
   - src: /images/uploads/jr-02.jpg

--- a/src/data/projects/jr-03.md
+++ b/src/data/projects/jr-03.md
@@ -1,5 +1,6 @@
 ---
 name: jr-03
+online: true
 title: jr-03
 images:
   - src: /images/uploads/jr-03.jpg

--- a/src/data/projects/jr-04.md
+++ b/src/data/projects/jr-04.md
@@ -1,5 +1,6 @@
 ---
 name: jr-04
+online: true
 title: jr-04
 images:
   - src: /images/uploads/jr-04.jpg

--- a/src/data/projects/jr-05.md
+++ b/src/data/projects/jr-05.md
@@ -1,5 +1,6 @@
 ---
 name: jr-05
+online: true
 title: jr-05
 images:
   - src: /images/uploads/jr-05.jpg

--- a/src/data/projects/jr-06.md
+++ b/src/data/projects/jr-06.md
@@ -1,5 +1,6 @@
 ---
 name: jr-06
+online: true
 title: jr-06
 images:
   - src: /images/uploads/jr-06.jpg

--- a/src/data/projects/jr-07.md
+++ b/src/data/projects/jr-07.md
@@ -1,5 +1,6 @@
 ---
 name: jr-07
+online: true
 title: jr-07
 images:
   - src: /images/uploads/jr-07.jpg

--- a/src/data/projects/jr-08.md
+++ b/src/data/projects/jr-08.md
@@ -1,5 +1,6 @@
 ---
 name: jr-08
+online: true
 title: jr-08
 images:
   - src: /images/uploads/jr-08.jpg

--- a/src/data/projects/jr-09.md
+++ b/src/data/projects/jr-09.md
@@ -1,5 +1,6 @@
 ---
 name: jr-09
+online: true
 title: jr-09
 images:
   - src: /images/uploads/jr-09.jpg

--- a/src/data/projects/jr-10.md
+++ b/src/data/projects/jr-10.md
@@ -1,5 +1,6 @@
 ---
 name: jr-10
+online: true
 title: jr-10
 images:
   - src: /images/uploads/jr-10.jpg

--- a/src/data/projects/jr-11.md
+++ b/src/data/projects/jr-11.md
@@ -1,5 +1,6 @@
 ---
 name: jr-11
+online: true
 title: jr-11
 images:
   - src: /images/uploads/jr-11.jpg

--- a/src/data/projects/jr-12.md
+++ b/src/data/projects/jr-12.md
@@ -1,5 +1,6 @@
 ---
 name: jr-12
+online: true
 title: jr-12
 images:
   - src: /images/uploads/jr-12.jpg

--- a/src/data/projects/jr-13.md
+++ b/src/data/projects/jr-13.md
@@ -1,5 +1,6 @@
 ---
 name: jr-13
+online: true
 title: jr-13
 images:
   - src: /images/uploads/jr-13.jpg

--- a/src/data/projects/jr-14.md
+++ b/src/data/projects/jr-14.md
@@ -1,5 +1,6 @@
 ---
 name: jr-14
+online: true
 title: jr-14
 images:
   - src: /images/uploads/jr-14.jpg

--- a/src/data/projects/jr-15.md
+++ b/src/data/projects/jr-15.md
@@ -1,5 +1,6 @@
 ---
 name: jr-15
+online: true
 title: jr-15
 images:
   - src: /images/uploads/jr-15.jpg

--- a/src/data/projects/jr-16.md
+++ b/src/data/projects/jr-16.md
@@ -1,5 +1,6 @@
 ---
 name: jr-16
+online: true
 title: jr-16
 images:
   - src: /images/uploads/jr-16.jpg

--- a/src/data/projects/jr-17.md
+++ b/src/data/projects/jr-17.md
@@ -1,5 +1,6 @@
 ---
 name: jr-17
+online: true
 title: jr-17
 images:
   - src: /images/uploads/jr-17.jpg

--- a/src/data/projects/jr-18.md
+++ b/src/data/projects/jr-18.md
@@ -1,5 +1,6 @@
 ---
 name: jr-18
+online: true
 title: jr-18
 images:
   - src: /images/uploads/jr-18.jpg

--- a/src/data/projects/jr-19.md
+++ b/src/data/projects/jr-19.md
@@ -1,5 +1,6 @@
 ---
 name: jr-19
+online: true
 title: jr-19
 images:
   - src: /images/uploads/jr-19.jpg

--- a/src/data/projects/jr-20.md
+++ b/src/data/projects/jr-20.md
@@ -1,5 +1,6 @@
 ---
 name: jr-20
+online: true
 title: jr-20
 images:
   - src: /images/uploads/jr-20.jpg

--- a/src/data/projects/jr-21.md
+++ b/src/data/projects/jr-21.md
@@ -1,5 +1,6 @@
 ---
 name: jr-21
+online: true
 title: jr-21
 images:
   - src: /images/uploads/jr-21.jpg

--- a/src/data/projects/jr-22.md
+++ b/src/data/projects/jr-22.md
@@ -1,5 +1,6 @@
 ---
 name: jr-22
+online: true
 title: jr-22
 images:
   - src: /images/uploads/jr-22.jpg

--- a/src/data/projects/jr-23.md
+++ b/src/data/projects/jr-23.md
@@ -1,5 +1,6 @@
 ---
 name: jr-23
+online: true
 title: jr-23
 images:
   - src: /images/uploads/jr-23.jpg

--- a/src/data/projects/jr-24.md
+++ b/src/data/projects/jr-24.md
@@ -1,5 +1,6 @@
 ---
 name: jr-24
+online: true
 title: jr-24
 images:
   - src: /images/uploads/jr-24.jpg

--- a/src/data/projects/jr-25.md
+++ b/src/data/projects/jr-25.md
@@ -1,5 +1,6 @@
 ---
 name: jr-25
+online: true
 title: jr-25
 images:
   - src: /images/uploads/jr-25.jpg

--- a/src/data/projects/jr-26.md
+++ b/src/data/projects/jr-26.md
@@ -1,5 +1,6 @@
 ---
 name: jr-26
+online: true
 title: jr-26
 images:
   - src: /images/uploads/jr-26.jpg

--- a/src/data/projects/jr-27.md
+++ b/src/data/projects/jr-27.md
@@ -1,5 +1,6 @@
 ---
 name: jr-27
+online: true
 title: jr-27
 images:
   - src: /images/uploads/jr-27.jpg

--- a/src/data/projects/jr-28.md
+++ b/src/data/projects/jr-28.md
@@ -1,5 +1,6 @@
 ---
 name: jr-28
+online: true
 title: jr-28
 images:
   - src: /images/uploads/jr-28.jpg

--- a/src/data/projects/jr-29.md
+++ b/src/data/projects/jr-29.md
@@ -1,5 +1,6 @@
 ---
 name: jr-29
+online: true
 title: jr-29
 images:
   - src: /images/uploads/jr-29.jpg

--- a/src/data/projects/jr-30.md
+++ b/src/data/projects/jr-30.md
@@ -1,5 +1,6 @@
 ---
 name: jr-30
+online: true
 title: jr-30
 images:
   - src: /images/uploads/jr-30.jpg

--- a/src/data/projects/jr-31.md
+++ b/src/data/projects/jr-31.md
@@ -1,5 +1,6 @@
 ---
 name: jr-31
+online: true
 title: jr-31
 images:
   - src: /images/uploads/jr-31.jpg

--- a/src/data/projects/jr-32.md
+++ b/src/data/projects/jr-32.md
@@ -1,5 +1,6 @@
 ---
 name: jr-32
+online: true
 title: jr-32
 images:
   - src: /images/uploads/jr-32.jpg

--- a/src/data/projects/jr-33.md
+++ b/src/data/projects/jr-33.md
@@ -1,5 +1,6 @@
 ---
 name: jr-33
+online: true
 title: jr-33
 images:
   - src: /images/uploads/jr-33.jpg

--- a/src/data/projects/jr-34.md
+++ b/src/data/projects/jr-34.md
@@ -1,5 +1,6 @@
 ---
 name: jr-34
+online: true
 title: jr-34
 images:
   - src: /images/uploads/jr-34.jpg

--- a/src/data/projects/jr-35.md
+++ b/src/data/projects/jr-35.md
@@ -1,5 +1,6 @@
 ---
 name: jr-35
+online: true
 title: jr-35
 images:
   - src: /images/uploads/jr-35.jpg

--- a/src/data/projects/jr-36.md
+++ b/src/data/projects/jr-36.md
@@ -1,5 +1,6 @@
 ---
 name: jr-36
+online: true
 title: jr-36
 images:
   - src: /images/uploads/jr-36.jpg

--- a/src/data/projects/jr-37.md
+++ b/src/data/projects/jr-37.md
@@ -1,5 +1,6 @@
 ---
 name: jr-37
+online: true
 title: jr-37
 images:
   - src: /images/uploads/jr-37.jpg

--- a/src/data/projects/jr-38.md
+++ b/src/data/projects/jr-38.md
@@ -1,5 +1,6 @@
 ---
 name: jr-38
+online: true
 title: jr-38
 images:
   - src: /images/uploads/jr-38.jpg

--- a/src/data/projects/jr-39.md
+++ b/src/data/projects/jr-39.md
@@ -1,5 +1,6 @@
 ---
 name: jr-39
+online: true
 title: jr-39
 images:
   - src: /images/uploads/jr-39.jpg

--- a/src/data/projects/jr-40.md
+++ b/src/data/projects/jr-40.md
@@ -1,5 +1,6 @@
 ---
 name: jr-40
+online: true
 title: jr-40
 images:
   - src: /images/uploads/jr-40.jpg

--- a/src/data/projects/jr-41.md
+++ b/src/data/projects/jr-41.md
@@ -1,5 +1,6 @@
 ---
 name: jr-41
+online: true
 title: jr-41
 images:
   - src: /images/uploads/jr-41.jpg

--- a/src/data/projects/jr-42.md
+++ b/src/data/projects/jr-42.md
@@ -1,5 +1,6 @@
 ---
 name: jr-42
+online: true
 title: jr-42
 images:
   - src: /images/uploads/jr-42.jpg

--- a/src/data/projects/jr-43.md
+++ b/src/data/projects/jr-43.md
@@ -1,5 +1,6 @@
 ---
 name: jr-43
+online: true
 title: jr-43
 images:
   - src: /images/uploads/jr-43.jpg

--- a/src/data/projects/jr-44.md
+++ b/src/data/projects/jr-44.md
@@ -1,5 +1,6 @@
 ---
 name: jr-44
+online: true
 title: jr-44
 images:
   - src: /images/uploads/jr-44.jpg

--- a/src/data/projects/jr-45.md
+++ b/src/data/projects/jr-45.md
@@ -1,5 +1,6 @@
 ---
 name: jr-45
+online: true
 title: jr-45
 images:
   - src: /images/uploads/jr-45.jpg

--- a/src/data/projects/jr-46.md
+++ b/src/data/projects/jr-46.md
@@ -1,5 +1,6 @@
 ---
 name: jr-46
+online: true
 title: jr-46
 images:
   - src: /images/uploads/jr-46.jpg

--- a/src/data/projects/jr-47.md
+++ b/src/data/projects/jr-47.md
@@ -1,5 +1,6 @@
 ---
 name: jr-47
+online: true
 title: jr-47
 images:
   - src: /images/uploads/jr-47.jpg

--- a/src/data/projects/jr-48.md
+++ b/src/data/projects/jr-48.md
@@ -1,5 +1,6 @@
 ---
 name: jr-48
+online: true
 title: jr-48
 images:
   - src: /images/uploads/jr-48.jpg

--- a/src/data/projects/jr-49.md
+++ b/src/data/projects/jr-49.md
@@ -1,5 +1,6 @@
 ---
 name: jr-49
+online: true
 title: jr-49
 images:
   - src: /images/uploads/jr-49.jpg

--- a/src/data/projects/jr-50.md
+++ b/src/data/projects/jr-50.md
@@ -1,5 +1,6 @@
 ---
 name: jr-50
+online: true
 title: jr-50
 images:
   - src: /images/uploads/jr-50.jpg

--- a/src/data/projects/jr-51.md
+++ b/src/data/projects/jr-51.md
@@ -1,5 +1,6 @@
 ---
 name: jr-51
+online: true
 title: jr-51
 images:
   - src: /images/uploads/jr-51.jpg

--- a/src/data/projects/jr-52.md
+++ b/src/data/projects/jr-52.md
@@ -1,5 +1,6 @@
 ---
 name: jr-52
+online: true
 title: jr-52
 images:
   - src: /images/uploads/jr-52.jpg

--- a/src/data/projects/jr-53.md
+++ b/src/data/projects/jr-53.md
@@ -1,5 +1,6 @@
 ---
 name: jr-53
+online: true
 title: jr-53
 images:
   - src: /images/uploads/jr-53.jpg

--- a/src/data/projects/jr-54.md
+++ b/src/data/projects/jr-54.md
@@ -1,5 +1,6 @@
 ---
 name: jr-54
+online: true
 title: jr-54
 images:
   - src: /images/uploads/jr-54.jpg

--- a/src/data/projects/toberecovereddead_video_textflow.md
+++ b/src/data/projects/toberecovereddead_video_textflow.md
@@ -1,5 +1,6 @@
 ---
 name: toberecovereddead_video_textflow
+online: true
 title: toberecovereddead_video_textflow
 category: B
 kind: video

--- a/src/data/projects/toberecovereddead_video_wasser.md
+++ b/src/data/projects/toberecovereddead_video_wasser.md
@@ -1,5 +1,6 @@
 ---
 name: toberecovereddead_video_wasser
+online: true
 title: toberecovereddead_video_wasser
 category: B
 kind: video

--- a/src/data/projects/{name}-1.md
+++ b/src/data/projects/{name}-1.md
@@ -1,5 +1,6 @@
 ---
 name: "404"
+online: true
 category: B
 kind: video
 video: https://stream.mux.com/FPnAaq0201Bpl786eSXxPUM6D55fx93U9VIPNvid2WEMk.m3u8

--- a/src/data/projects/{name}-2.md
+++ b/src/data/projects/{name}-2.md
@@ -1,5 +1,6 @@
 ---
 name: text
+online: true
 title: "404: Not Found"
 category: B
 kind: text

--- a/src/data/projects/{name}-3.md
+++ b/src/data/projects/{name}-3.md
@@ -1,5 +1,6 @@
 ---
 name: text
+online: true
 title: "404: Not Found "
 category: B
 kind: text

--- a/src/data/projects/{name}-4.md
+++ b/src/data/projects/{name}-4.md
@@ -1,5 +1,6 @@
 ---
 name: yolo
+online: true
 category: B
 kind: image
 startTime: 0

--- a/src/data/projects/{name}-5.md
+++ b/src/data/projects/{name}-5.md
@@ -1,5 +1,6 @@
 ---
 name: mmmmmmm
+online: true
 title: hhh
 category: B
 kind: text

--- a/src/data/projects/{name}.md
+++ b/src/data/projects/{name}.md
@@ -1,5 +1,6 @@
 ---
 name: TEST2
+online: true
 title: ohoh
 category: B
 kind: text

--- a/src/data/projects/{slug}.md
+++ b/src/data/projects/{slug}.md
@@ -1,5 +1,6 @@
 ---
 name: text 4
+online: true
 title: "{{name}}"
 category: B
 kind: text

--- a/src/data/projects/{{name}}.md
+++ b/src/data/projects/{{name}}.md
@@ -1,5 +1,6 @@
 ---
 name: tex3
+online: true
 title: "{{name}}"
 category: B
 kind: text

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -8,7 +8,7 @@ import Preloader from "../components/Preloader.astro";
 const title = "Jannis Reinelt - About";
 const allProjects = await getCollection("projects");
 const projects = allProjects
-  .filter((p) => p.data.category === 'A')
+  .filter((p) => p.data.category === 'A' && p.data.online)
   .sort((a, b) => (a.data.order_about ?? 0) - (b.data.order_about ?? 0));
 ---
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,7 +7,7 @@ import Preloader from "../components/Preloader.astro";
 
 const allProjects = await getCollection("projects");
 const projects = allProjects
-  .filter((p) => p.data.category === 'B')
+  .filter((p) => p.data.category === 'B' && p.data.online)
   .sort((a, b) => (a.data.order_projects ?? 0) - (b.data.order_projects ?? 0));
 const projectsTotal = projects.length;
 const title = "Jannis Reinelt";

--- a/src/pages/video-light-camera.astro
+++ b/src/pages/video-light-camera.astro
@@ -9,7 +9,7 @@ const title = "Jannis Reinelt - Video/Light/Camera";
 
 const allProjects = await getCollection("projects");
 const projects = allProjects
-  .filter((p) => p.data.category === 'C')
+  .filter((p) => p.data.category === 'C' && p.data.online)
   .sort((a, b) => (a.data.order_video ?? 0) - (b.data.order_video ?? 0));
 ---
 


### PR DESCRIPTION
## Summary
- add `online` boolean to project frontmatter and schema
- filter pages to only display projects with `online: true`
- expose `online` toggle in CMS configs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a39dabc1ec8327a0c41ca2747ca729