### PR TITLE
fix: support full video URLs

### DIFF
--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -12,6 +12,11 @@ const bodyEN = (project.data.body_en ?? "").toString();
 // Always use filename (slug) for name
 const nameFromFile = project.slug;
 const title = project.data.title ?? nameFromFile;
+const videoUrl = project.data.video
+  ? project.data.video.includes('://')
+    ? project.data.video
+    : `https://stream.mux.com/${project.data.video}.m3u8`
+  : "";
 ---
 
 <div
@@ -41,7 +46,7 @@ const title = project.data.title ?? nameFromFile;
       loop
       controls
       data-start-time={project.data.startTime}
-      data-hls={`https://stream.mux.com/${project.data.video}.m3u8`}
+      data-hls={videoUrl}
       data-max-height="1080"
     ></video>
     <button class="mute-toggle" aria-label="Toggle sound">unmute</button>


### PR DESCRIPTION
## Summary
- handle project videos provided as full Mux URLs or playback IDs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1bef5f4888327a3dd3866a829e45a